### PR TITLE
Use ARM64 image for ARM64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ros-$(DISTRO)-%-$(OS_VERSION)_amd64.run: FORCE
 		make ros-$(DISTRO)-$*-$(OS_VERSION)_native.run AS=ros-$(DISTRO)-$*_$(VERSION)-$(OS_VERSION)_amd64.run NUM_JOBS=$(NUM_JOBS)
 
 ros-$(DISTRO)-%-$(OS_VERSION)_arm64.run: FORCE  # extremely slow
-	docker build -t arm64-bundler-image --platform linux/arm64/v8 -f $(DOCKER_DIR)/amd64/Dockerfile $(MAKEFILE_DIR)
+	docker build -t arm64-bundler-image --platform linux/arm64/v8 -f $(DOCKER_DIR)/arm64/Dockerfile $(MAKEFILE_DIR)
 	docker run --rm -v $(MAKEFILE_DIR):/workspace:cached -w /workspace --platform linux/arm64/v8 -it arm64-bundler-image \
 		make ros-$(DISTRO)-$*-$(OS_VERSION)_native.run AS=ros-$(DISTRO)-$*_$(VERSION)-$(OS_VERSION)_arm64.run NUM_JOBS=$(NUM_JOBS)
 


### PR DESCRIPTION
Precisely what the title says. Follow-up after #14. 