### PR TITLE
[SW-1111] Bump bosdyn_msgs to spot-sdk 4.0.2

### DIFF
--- a/bosdyn_api_msgs/package.xml
+++ b/bosdyn_api_msgs/package.xml
@@ -5,7 +5,7 @@ Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK core APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_auto_return_api_msgs/package.xml
+++ b/bosdyn_auto_return_api_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_auto_return_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK auto-return APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_autowalk_api_msgs/package.xml
+++ b/bosdyn_autowalk_api_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_autowalk_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK autowalk APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_cmake_module/package.xml
+++ b/bosdyn_cmake_module/package.xml
@@ -5,7 +5,7 @@ Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_cmake_module</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>CMake modules for Boston Dynamics Spot SDK</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_graph_nav_api_msgs/package.xml
+++ b/bosdyn_graph_nav_api_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_graph_nav_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK graph nav APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_keepalive_api_msgs/package.xml
+++ b/bosdyn_keepalive_api_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_keepalive_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK keepalive APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_log_status_api_msgs/package.xml
+++ b/bosdyn_log_status_api_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_log_status_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK log status APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_metrics_logging_api_msgs/package.xml
+++ b/bosdyn_metrics_logging_api_msgs/package.xml
@@ -5,7 +5,7 @@ Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_metrics_logging_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK metrics logging APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_mission_api_msgs/package.xml
+++ b/bosdyn_mission_api_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_mission_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK mission APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_msgs/package.xml
+++ b/bosdyn_msgs/package.xml
@@ -5,7 +5,7 @@ Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>ROS 2 interoperability support for Boston Dynamics Spot SDK APIs</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_spot_api_msgs/package.xml
+++ b/bosdyn_spot_api_msgs/package.xml
@@ -5,7 +5,7 @@ Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_spot_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>Boston Dynamics Spot API ROS 2 interfaces</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/bosdyn_spot_cam_api_msgs/package.xml
+++ b/bosdyn_spot_cam_api_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>bosdyn_spot_cam_api_msgs</name>
-  <version>4.0.0</version>
+  <version>4.0.2</version>
   <description>Boston Dynamics Spot API ROS 2 interfaces</description>
   <maintainer email="engineering@theaiinstitute.com">BD AI Institute</maintainer>
   <license>MIT</license>

--- a/pip-constraint.txt
+++ b/pip-constraint.txt
@@ -1,4 +1,3 @@
 bosdyn-api==4.0.2
-bosdyn-choreography-protos==4.0.2
 # ensure protoc 3.12.4 compatibility
 protobuf<=4.22.4

--- a/pip-constraint.txt
+++ b/pip-constraint.txt
@@ -1,4 +1,4 @@
-bosdyn-api==4.0.0
-bosdyn-choreography-protos==4.0.0
+bosdyn-api==4.0.2
+bosdyn-choreography-protos==4.0.2
 # ensure protoc 3.12.4 compatibility
 protobuf<=4.22.4


### PR DESCRIPTION
Changes all references from 4.0.0 to 4.0.2 so that we can generate a release for 4.0.2