### PR TITLE
[SW-1712] Pin ubuntu version in workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
         - { platform: "linux/amd64", arch: "amd64" }
         - { platform: "linux/arm64/v8", arch: "arm64" }
     name: Build ${{ matrix.config.arch }} bundler image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -73,7 +73,7 @@ jobs:
           retention-days: 1
   merge-container-images:  # so that a unique tag + platform dictate which container image is used
     name: Merge all bundler images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-container-images]
     permissions:
       contents: read
@@ -135,7 +135,7 @@ jobs:
           retention-days: 1
   release-bundles:
     name: Release all bundles
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-bundles] 
     steps:
       - name: Download bundles

--- a/.github/workflows/mirror-release.yml
+++ b/.github/workflows/mirror-release.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   mirror-latest-release:  # only applies to workflow events
     name: Mirror latest bosdyn_msgs release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
@@ -37,7 +37,7 @@ jobs:
           files: '*.run'
   mirror-published-release:  # only applies to release events
     name: Mirror published bosdyn_msgs release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'release' }}
     permissions:
       contents: write


### PR DESCRIPTION
## Change Overview

This is simply a find/replace of `ubuntu-latest` -> `ubuntu-22.04`.  Because `ubuntu-latest` will become 24.04 soon.  We should pin to 22.04 which matches our development environment.

## Testing Done

None. This PR is the test.  (Assuming this repo has CI)

