### PR TITLE
Change to new RAI Institute copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/bosdyn_api_msgs/CMakeLists.txt
+++ b/bosdyn_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.12)
 project(bosdyn_api_msgs)
 

--- a/bosdyn_api_msgs/bosdyn_api_msgs/manual_conversions.py
+++ b/bosdyn_api_msgs/bosdyn_api_msgs/manual_conversions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import bosdyn.api.geometry_pb2
 import geometry_msgs.msg

--- a/bosdyn_api_msgs/bosdyn_api_msgs/math_helpers.py
+++ b/bosdyn_api_msgs/bosdyn_api_msgs/math_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Callable, Optional, Tuple, Union
 

--- a/bosdyn_api_msgs/include/bosdyn_api_msgs/manual_conversions.hpp
+++ b/bosdyn_api_msgs/include/bosdyn_api_msgs/manual_conversions.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 #pragma once
 

--- a/bosdyn_api_msgs/package.xml
+++ b/bosdyn_api_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 -->
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">

--- a/bosdyn_api_msgs/src/manual_conversions.cpp
+++ b/bosdyn_api_msgs/src/manual_conversions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 #include "bosdyn_api_msgs/manual_conversions.hpp"
 

--- a/bosdyn_auto_return_api_msgs/CMakeLists.txt
+++ b/bosdyn_auto_return_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_auto_return_api_msgs)
 

--- a/bosdyn_autowalk_api_msgs/CMakeLists.txt
+++ b/bosdyn_autowalk_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_autowalk_api_msgs)
 

--- a/bosdyn_cmake_module/CMakeLists.txt
+++ b/bosdyn_cmake_module/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.12)
 project(bosdyn_cmake_module)
 

--- a/bosdyn_cmake_module/cmake/fetch_spot_sdk.cmake
+++ b/bosdyn_cmake_module/cmake/fetch_spot_sdk.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 macro(fetch_spot_sdk target)
   get_executable_path(PYTHON_EXECUTABLE Python3::Interpreter CONFIGURE)

--- a/bosdyn_cmake_module/package.xml
+++ b/bosdyn_cmake_module/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 -->
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">

--- a/bosdyn_graph_nav_api_msgs/CMakeLists.txt
+++ b/bosdyn_graph_nav_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_graph_nav_api_msgs)
 

--- a/bosdyn_keepalive_api_msgs/CMakeLists.txt
+++ b/bosdyn_keepalive_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_keepalive_api_msgs)
 

--- a/bosdyn_log_status_api_msgs/CMakeLists.txt
+++ b/bosdyn_log_status_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_log_status_api_msgs)
 

--- a/bosdyn_metrics_logging_api_msgs/CMakeLists.txt
+++ b/bosdyn_metrics_logging_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_metrics_logging_api_msgs)
 

--- a/bosdyn_metrics_logging_api_msgs/package.xml
+++ b/bosdyn_metrics_logging_api_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 -->
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">

--- a/bosdyn_mission_api_msgs/CMakeLists.txt
+++ b/bosdyn_mission_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_mission_api_msgs)
 

--- a/bosdyn_msgs/CMakeLists.txt
+++ b/bosdyn_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.12)
 project(bosdyn_msgs)
 

--- a/bosdyn_msgs/bosdyn_msgs/__init__.py
+++ b/bosdyn_msgs/bosdyn_msgs/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/bosdyn_msgs/bosdyn_msgs/conversions.py
+++ b/bosdyn_msgs/bosdyn_msgs/conversions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import bosdyn_api_msgs.conversions as _  # noqa
 import bosdyn_auto_return_api_msgs.conversions as _  # noqa

--- a/bosdyn_msgs/bosdyn_msgs/msg/__init__.py
+++ b/bosdyn_msgs/bosdyn_msgs/msg/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from bosdyn_api_msgs.msg import *  # noqa
 from bosdyn_auto_return_api_msgs.msg import *  # noqa

--- a/bosdyn_msgs/package.xml
+++ b/bosdyn_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
+Copyright (c) 2023-2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 -->
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">

--- a/bosdyn_spot_api_msgs/CMakeLists.txt
+++ b/bosdyn_spot_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_spot_api_msgs)
 

--- a/bosdyn_spot_api_msgs/package.xml
+++ b/bosdyn_spot_api_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 -->
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">

--- a/bosdyn_spot_cam_api_msgs/CMakeLists.txt
+++ b/bosdyn_spot_cam_api_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 cmake_minimum_required(VERSION 3.8)
 project(bosdyn_spot_cam_api_msgs)
 


### PR DESCRIPTION
Automated update to fix copyright headers with new organization name.

"Boston Dynamics AI Institute LLC" has been changed to "Robotics and AI Institute LLC" or "RAI Institute" for short.

Note that the date-stamps in the copyright headers have been preserved. Only files with existing copyrights have been modified.

This PR was created automatically.